### PR TITLE
Added stream_from_channel

### DIFF
--- a/src/edn.mli
+++ b/src/edn.mli
@@ -21,6 +21,8 @@ val from_string : string -> t
 
 val from_channel : in_channel -> t
 
+val stream_from_channel : in_channel -> t Stream.t
+
 module Errors : sig
   exception Error of string
 end

--- a/src/reader.ml
+++ b/src/reader.ml
@@ -8,3 +8,8 @@ let from_string s =
 
 let from_channel ch =
   parse (Lexing.from_channel ch)
+
+let stream_from_channel ch =
+  let lexbuf = Lexing.from_channel ch in
+  let f i = Edn_parser.prog Read.read lexbuf in
+  Stream.from f

--- a/src/reader.ml
+++ b/src/reader.ml
@@ -11,5 +11,5 @@ let from_channel ch =
 
 let stream_from_channel ch =
   let lexbuf = Lexing.from_channel ch in
-  let f i = Edn_parser.prog Read.read lexbuf in
+  let f _ = Edn_parser.prog Read.read lexbuf in
   Stream.from f


### PR DESCRIPTION
Related to #3. With this implementation I'm able to read multiple values in a streaming fashion with an expression like

``` ocaml
let _ = Stream.iter
          (fun edn -> print_endline (Edn.to_string edn))
          (Edn.stream_from_channel stdin)
```

```
$ ocamlbuild -use-ocamlfind -pkg=edn rdr.native
$ echo '{:foo [1 2 3]} #{:a :b :c}' | ./rdr.native
{:foo [1 2 3 ] }
#{:a :b :c }
```
