### PR TITLE
Fix nil/list writer values 

### DIFF
--- a/_tags
+++ b/_tags
@@ -4,4 +4,4 @@ true: use_menhir
 <src> : include, package(menhir)
 <test> : include
 
-<test/*> : package(ounit)
+<test/*> : package(oUnit)

--- a/src/edn_writer.ml
+++ b/src/edn_writer.ml
@@ -45,7 +45,7 @@ and write_int buf v =
 and write_float buf v =
   Buffer.add_string buf (string_of_float v)
 and write_nil buf =
-  Buffer.add_string buf "null"
+  Buffer.add_string buf "nil"
 and write_big_int buf v =
   Buffer.add_string buf (v ^ "N")
 and write_decimal buf v =

--- a/src/edn_writer.ml
+++ b/src/edn_writer.ml
@@ -28,9 +28,9 @@ and write_assoc buf xs =
     xs;
   Buffer.add_char buf '}';
 and write_list buf xs =
-  Buffer.add_char buf '{';
+  Buffer.add_char buf '(';
   List.iter (write_and_whitespace buf) xs;
-  Buffer.add_char buf '}'
+  Buffer.add_char buf ')'
 and write_vector buf xs =
   Buffer.add_char buf '[';
   List.iter (write_and_whitespace buf) xs;
@@ -79,4 +79,3 @@ let to_string edn =
   let buf = Buffer.create 256 in
   write buf edn;
   Buffer.to_bytes buf
-

--- a/test/test.ml
+++ b/test/test.ml
@@ -2,57 +2,60 @@ open OUnit2
 
 let edn_parse msg s expected =
   assert_equal ~msg ~printer: Edn.to_string
-    expected (Edn.from_string s)
+               expected (Edn.from_string s)
+
+let edn_write msg e s =
+  assert_equal ~msg: ((Edn.to_string e) ^ " " ^ s)
+               s (Edn.to_string e)
+
+let edn_roundtrip msg s e =
+  (edn_parse msg s e);
+  (edn_write msg e s)
 
 let basic_parsing1 _ =
-  edn_parse "nil" "nil" `Null;
-
-  edn_parse "true" "true" (`Bool true);
-  edn_parse "false" "false" (`Bool false);
-
+  edn_roundtrip "nil" "nil" `Null;
+  edn_roundtrip "true" "true" (`Bool true);
+  edn_roundtrip "false" "false" (`Bool false);
   edn_parse "string" "\"hello\nworld\"" (`String "hello\nworld");
-
-  edn_parse "symbol" "foo" (`Symbol (None, "foo"));
-  edn_parse "symbol with namespace" "bar/foo:#" (`Symbol ((Some "bar"), "foo:#"));
-
-  edn_parse "keyword" ":foo" (`Keyword (None, "foo"));
-  edn_parse "keyword with namespace" ":bar/foo:#" (`Keyword ((Some "bar"), "foo:#"));
-
-  edn_parse "standalone symbols" "(+ - .)" (`List [`Symbol (None, "+");
+  edn_roundtrip "symbol" "foo" (`Symbol (None, "foo"));
+  edn_roundtrip "symbol with namespace" "bar/foo:#" (`Symbol ((Some "bar"), "foo:#"));
+  edn_roundtrip "keyword" ":foo" (`Keyword (None, "foo"));
+  edn_roundtrip "keyword with namespace" ":bar/foo:#" (`Keyword ((Some "bar"), "foo:#"));
+  edn_roundtrip "standalone symbols" "(+ - . )" (`List [`Symbol (None, "+");
                                                    `Symbol (None, "-");
                                                    `Symbol (None, ".");]);
 
-  edn_parse "int" "1" (`Int 1);
-  edn_parse "int2" "123" (`Int 123);
+  edn_roundtrip "int" "1" (`Int 1);
+  edn_roundtrip "int2" "123" (`Int 123);
   edn_parse "positive int" "+1" (`Int 1);
   edn_parse "positive int2" "+123" (`Int 123);
-  edn_parse "negative int" "-1" (`Int (-1));
-  edn_parse "negative int2" "-123" (`Int (-123));
+  edn_roundtrip "negative int" "-1" (`Int (-1));
+  edn_roundtrip "negative int2" "-123" (`Int (-123));
 
-  edn_parse "big int" "123N" (`BigInt "123");
+  edn_roundtrip "big int" "123N" (`BigInt "123");
 
-  edn_parse "float" "1.2" (`Float 1.2);
-  edn_parse "float2" "123.2" (`Float 123.2);
+  edn_roundtrip "float" "1.2" (`Float 1.2);
+  edn_roundtrip "float2" "123.2" (`Float 123.2);
   edn_parse "positive float" "+1.2" (`Float 1.2);
   edn_parse "positive float2" "+123.2" (`Float 123.2);
-  edn_parse "negative float" "-1.2" (`Float (-1.2));
-  edn_parse "negative float2" "-123.2" (`Float (-123.2));
+  edn_roundtrip "negative float" "-1.2" (`Float (-1.2));
+  edn_roundtrip "negative float2" "-123.2" (`Float (-123.2));
   edn_parse "exp float" "123.E33" (`Float 123.E33);
 
-  edn_parse "decimal" "123.123M" (`Decimal "123.123");
+  edn_roundtrip "decimal" "123.123M" (`Decimal "123.123");
 
-  edn_parse "list" "(1 \"2\" :a)" (`List [`Int 1; `String "2"; `Keyword (None, "a")]);
+  edn_roundtrip "list" "(1 \"2\" :a )" (`List [`Int 1; `String "2"; `Keyword (None, "a")]);
 
-  edn_parse "vector" "[1 \"2\" :a]" (`Vector [`Int 1; `String "2"; `Keyword (None, "a")]);
+  edn_roundtrip "vector" "[1 \"2\" :a ]" (`Vector [`Int 1; `String "2"; `Keyword (None, "a")]);
 
   edn_parse "map" "{:a 1, \"foo\" :bar, [1 2 3] four}"
     (`Assoc [(`Keyword (None, "a"), `Int 1);
              (`String "foo", `Keyword (None, "bar"));
              (`Vector [`Int 1; `Int 2; `Int 3], `Symbol (None, "four"))]);
 
-  edn_parse "set" "#{1 \"2\" :a}" (`Set [`Int 1; `String "2"; `Keyword (None, "a")]);
+  edn_roundtrip "set" "#{1 \"2\" :a }" (`Set [`Int 1; `String "2"; `Keyword (None, "a")]);
 
-  edn_parse "tag" "#myapp/Person \"Andrew\""
+  edn_roundtrip "tag" "#myapp/Person \"Andrew\""
     (`Tag ((Some "myapp"), "Person", `String "Andrew"));
 
   edn_parse "comments" "[1\n;2\n3]" (`Vector [`Int 1; `Int 3]);
@@ -69,7 +72,7 @@ let basic_parsing1 _ =
 
 let suite =
   "parsing" >:::
-  ["basic_parsing1">:: basic_parsing1]
+    ["basic_parsing1">:: basic_parsing1]
 
 let () =
   run_test_tt_main suite


### PR DESCRIPTION
Hi, 

The writer would emit wrong EDN List types (they are inclosed by `{...}`, when it should be `(...)`. Same for `nil`, `null` was being emitted instead. 

I took the liberty to add a few tests for this and allow to have roundtrip tests (string to edn and edn back to string in 1 test unit).

I also had to fix the _tag file so that it would work on case sensitive file systems (ex any ext\* based fs). 
