### PR TITLE
Get string out of buffer instead of bytes

### DIFF
--- a/src/edn_writer.ml
+++ b/src/edn_writer.ml
@@ -82,4 +82,4 @@ and write_char buf v =
 let to_string edn =
   let buf = Buffer.create 256 in
   write buf edn;
-  Buffer.to_bytes buf
+  Buffer.contents buf


### PR DESCRIPTION
Since OCaml 4.06 -safe-string is default, which makes string and bytes distinct types.

Fixes #11